### PR TITLE
Add qualification-sub-level field to qualification-level register

### DIFF
--- a/data/qualification-level.tsv
+++ b/data/qualification-level.tsv
@@ -1,17 +1,17 @@
-qualification-level	name	european-qualification-framework-level	start-date	end-date
-EntryLevel	Entry Level			2016-07-07
-Entry1	Entry 1			
-Entry2	Entry 2			
-Entry3	Entry 3	Level 1		
-Entry1_2	Entry 1,2			
-Entry2_3	Entry 2,3			
-Entry1_2_3	Entry 1,2,3			
-Level1	Level 1	Level 2		
-Level1_2	Level 1/2	Level 2/3		
-Level2	Level 2	Level 3		
-Level3	Level 3	Level 4		
-Level4	Level 4	Level 5		
-Level5	Level 5	Level 5		
-Level6	Level 6	Level 6		
-Level7	Level 7	Level 7		
-Level8	Level 8	Level 8		
+qualification-level	name	qualification-sub-level	european-qualification-framework-level	start-date	end-date
+EntryLevel	Entry Level				2016-07-07
+Entry1	Entry Level	Entry Level 1			
+Entry2	Entry Level	Entry Level 2			
+Entry3	Entry Level	Entry Level 3	Level 1		
+Entry1_2	Entry Level	Entry Level 1,2			
+Entry2_3	Entry Level	Entry Level 2,3			
+Entry1_2_3	Entry Level	Entry Level 1,2,3			
+Level1	Level 1		Level 2		
+Level1_2	Level 1/2		Level 2/3		
+Level2	Level 2		Level 3		
+Level3	Level 3		Level 4		
+Level4	Level 4		Level 5		
+Level5	Level 5		Level 5		
+Level6	Level 6		Level 6		
+Level7	Level 7		Level 7		
+Level8	Level 8		Level 8		

--- a/data/qualification-sector-subject-area.tsv
+++ b/data/qualification-sector-subject-area.tsv
@@ -1,4 +1,4 @@
-qualification-subject	parent-qualification-subject	name	start-date	end-date
+qualification-sector-subject-area	parent-qualification-sector-subject-area	name	start-date	end-date
 01		Health, Public Services and Care		
 02		Science and Mathematics		
 03		Agriculture, Horticulture and Animal Care		


### PR DESCRIPTION
Agreed with custodian and tech arch.  Some misgivings about the fact that the
'name' field and the qualification-sub-level field are both names, but aren't
named the same, but it isn't worth normalising everything into a separate
qualification-sub-level register.